### PR TITLE
Update _nav.html.haml

### DIFF
--- a/source/layouts/_nav.html.haml
+++ b/source/layouts/_nav.html.haml
@@ -5,7 +5,7 @@
     %nav
       %ul
         %li{class: nav_active('difference')}= link_to 'The Difference', 'http://turing.io/difference'
-        %li{class: nav_active('team')}= link_to 'Team', 'http://turing.io/team'
+        %li{class: nav_active('team')}= link_to 'Our Team', 'http://turing.io/team'
         %li{class: nav_active('program')}= link_to 'Program', 'http://turing.io/program'
         %li{class: nav_active('admissions')}= link_to 'Admissions', 'http://turing.io/admissions'
         %li{class: nav_active('tuition')}= link_to 'Tuition', 'http://turing.io/tuition'


### PR DESCRIPTION
turing.io maintains the naming convention "Our Team" through all pages

bug originally found by https://github.com/allpurposename